### PR TITLE
修复

### DIFF
--- a/2026/第十三期.md
+++ b/2026/第十三期.md
@@ -33,7 +33,6 @@
 ### 2.1 知识包：KV Cache注入与状态空间引航
 
 > Knowledge Packs: Zero-Token Knowledge Delivery via KV Cache Injection
-> 来源：2026年4月草稿
 
 - **研究背景 (Motivation)**：在大规模检索增强生成（RAG）领域，长期存在的瓶颈是检索内容导致的正向推理Token开销随事实数量线性增长。这不仅极大地消耗了算力，还增加了由于长历史上下文累积带来的延迟。
 - **核心机制/方法 (Methodology)**：研究提出利用Transformer架构中的“键值对（KV）前缀等价性”。通过预先对大量事实进行离线前向传播，提取其KV缓存序列化为“知识包”。在推理时，通过将预计算状态直接注入推理引擎，使得查询序列直接与事实隐藏状态进行交互。同时揭示了“值空间导引”的二阶效应，通过对缓存Value进行向量算术运算来改变生成风格。
@@ -43,7 +42,6 @@
 ### 2.2 StableTTA：聚合策略优化的数学突破
 
 > StableTTA: Training-Free Test-Time Adaptation that Improves Model Accuracy on ImageNet1K to 96%
-> 来源：2026年4月草稿
 
 - **研究背景 (Motivation)**：在计算机视觉领域，提升ImageNet-1K的表现通常依赖增加数据或扩大参数。测试时增强（TTA）中不同聚合策略之间（如硬投票、软投票与对数平均）在处理稀疏对数空间时容易产生冲突和互斥的预测。
 - **核心机制/方法 (Methodology)**：首次系统性识别并证明了由于Softmax函数和指示函数的非线性及非双射性质所导致的聚合冲突。提出了一种训练无关的混合方法，在图像预处理阶段引入稳定性约束，并在对数后处理阶段实施策略对齐，消除了不稳定性。
@@ -118,7 +116,7 @@
 ### 4.2 V-Reflection：视觉反思机制的深层修正
 
 > V-Reflection: Transforming MLLMs from Passive Observers to Active Interrogators
-> 来源：2026年4月草稿
+
 
 - **研究背景 (Motivation)**：多模态大语言模型（MLLM）在执行细粒度感知时，因无法根据推理状态重新审视视觉输入而易产生幻觉。
 - **核心机制/方法 (Methodology)**：提出“先思后看”的动态反射机制，将模型隐状态转化为动态探测器（Dynamic Probes）。通过两阶段蒸馏策略（显式空间锚定BCM与视觉隐空间蒸馏DAC），将空间解析能力内化，使模型能够根据思维轨迹自主在全球视觉图谱中定位证据。
@@ -128,7 +126,7 @@
 ### 4.3 StoryBlender：3D引擎驱动的叙事一致性
 
 > StoryBlender: Inter-Shot Consistent and Editable 3D Storyboard with Spatial-temporal Dynamics
-> 来源：2026年4月草稿
+
 
 - **研究背景 (Motivation)**：在视觉视频或图像合成中，跨镜头的角色身份漂移与几何一致性一直是技术瓶颈。
 - **核心机制/方法 (Methodology)**：将分镜生成转化为3D引擎中的层级化多智能体规划过程。构建包含分镜大纲、资产表等四层的“连续性记忆图”，解耦全局资产（身份）与局部变量（动作、光影），并通过引擎物理验证提供反馈循环进行自我修正。

--- a/2026/第十三期_en.md
+++ b/2026/第十三期_en.md
@@ -33,7 +33,6 @@ Research in the first week of April 2026 reveals that academia is transforming m
 ### 2.1 Knowledge Packs: KV Cache Injection and State Space Steering
 
 > Knowledge Packs: Zero-Token Knowledge Delivery via KV Cache Injection
-> Source: April 2026 Draft
 
 - **Motivation**: In large-scale Retrieval-Augmented Generation (RAG), a persistent bottleneck is that the forward-pass token cost of retrieved content grows linearly with the number of facts. This not only consumes massive computational power but also increases latency due to the accumulation of long historical contexts.
 - **Methodology**: The study leverages the "KV-Prefix Equivalence" principle in the Transformer architecture. By performing offline forward passes on massive facts, it extracts and serializes their KV caches into "Knowledge Packs." During inference, by directly injecting pre-computed states into the inference engine, the query sequence interacts directly with the facts' hidden states. It also reveals the second-order effect of "Value-Space Steering," changing generation styles via vector arithmetic on cache Values.
@@ -43,7 +42,6 @@ Research in the first week of April 2026 reveals that academia is transforming m
 ### 2.2 StableTTA: Mathematical Breakthrough in Aggregation Strategy Optimization
 
 > StableTTA: Training-Free Test-Time Adaptation that Improves Model Accuracy on ImageNet1K to 96%
-> Source: April 2026 Draft
 
 - **Motivation**: In computer vision, improving performance on ImageNet-1K usually relies on adding data or scaling up parameters. In Test-Time Adaptation (TTA), different aggregation strategies (like hard voting, soft voting, and logit averaging) often produce conflicting and mutually exclusive predictions when handling sparse logit spaces.
 - **Methodology**: The study systematically identifies and proves that aggregation conflicts arise from the nonlinear and non-bijective nature of the Softmax and indicator functions. It proposes a training-free hybrid method that introduces stability constraints during image preprocessing and enforces strategy alignment during logit post-processing, eliminating instability.
@@ -89,7 +87,7 @@ Research in the first week of April 2026 reveals that academia is transforming m
 ### 3.3 AgentHazard: Security Defenses for Computer-Use Agents
 
 > AgentHazard: A Benchmark for Evaluating Harmful Behavior in Computer-Use Agents
-> Source: April 2026 Draft
+
 
 - **Motivation**: As agents gain capabilities for persistent operations and environment management, security risks have shifted from outputting "harmful speech" to "dynamic execution." Complex execution trajectories mean that combinations of seemingly legal single-step operations could lead to severe security vulnerabilities.
 - **Methodology**: It proposes an attack design philosophy of "locally legal, globally harmful," constructing a dynamic risk benchmark with 2,653 instances across 10 risk categories and 10 attack strategies. It focuses on testing trajectory-dependent vulnerabilities like persistent malware establishment and sensitive information exfiltration.
@@ -119,7 +117,7 @@ Research in the first week of April 2026 reveals that academia is transforming m
 ### 4.2 V-Reflection: Deep Correction via Visual Reflection Mechanism
 
 > V-Reflection: Transforming MLLMs from Passive Observers to Active Interrogators
-> Source: April 2026 Draft
+
 
 - **Motivation**: Multimodal Large Language Models (MLLMs) often hallucinate when executing fine-grained perception tasks because they cannot re-examine visual inputs based on their reasoning state.
 - **Methodology**: It proposes a "think before you look" dynamic reflection mechanism, transforming model latent states into Dynamic Probes. Through a two-stage distillation strategy (explicit spatial anchoring BCM and visual latent space distillation DAC), spatial parsing capabilities are internalized, enabling the model to autonomously locate evidence in the global visual graph based on its thought trajectory.
@@ -129,7 +127,7 @@ Research in the first week of April 2026 reveals that academia is transforming m
 ### 4.3 StoryBlender: 3D Engine-Driven Narrative Consistency
 
 > StoryBlender: Inter-Shot Consistent and Editable 3D Storyboard with Spatial-temporal Dynamics
-> Source: April 2026 Draft
+
 
 - **Motivation**: In visual video or image synthesis, cross-shot character identity drift and geometric consistency have always been technical bottlenecks.
 - **Methodology**: It reframes storyboard generation as a hierarchical multi-agent planning process within a 3D engine. It constructs a four-tier "Continuity Memory Graph" (including storyboard outlines and asset tables) to decouple global assets (identity) from local variables (action, lighting), and provides a feedback loop for self-correction via engine physical verification.


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

文档：
- 将 2026 年的中文和英文文档 Markdown 文件移动到更新后的路径中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Relocate the 2026 Chinese and English documentation markdown files to the updated path.

</details>